### PR TITLE
Feat/claude message enhance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules
 .vscode-test/
+.vscode/
 *.vsix
 dist/
 out/

--- a/package.json
+++ b/package.json
@@ -121,6 +121,18 @@
 					],
 					"description": "Which changes to use for generating commit messages",
 					"order": 7
+				},
+				"claudeCommit.claudeCodeManaged": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Claude Code managed mode: Let Claude Code's haiku model generate commit messages with minimal intervention (only language hint provided). **Only works when preferredMethod is 'cli'**",
+					"order": 8
+				},
+				"claudeCommit.keepCoAuthoredBy": {
+					"type": "boolean",
+					"default": false,
+					"markdownDescription": "Keep Co-Authored-By signature in commit message. **Only works in Claude Code managed mode**",
+					"order": 9
 				}
 			}
 		}

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -23,14 +23,21 @@ export function activate(context: vscode.ExtensionContext): void {
 
         const repo = git.repositories[0] as GitRepository;
 
-        if (
-          repo.state.indexChanges.length === 0 &&
-          repo.state.workingTreeChanges.length === 0
-        ) {
-          vscode.window.showWarningMessage(
-            "No changes to commit. Stage files first."
-          );
-          return;
+        // Skip change check in Claude Code managed mode (Claude Code will detect changes itself)
+        const config = vscode.workspace.getConfiguration("claudeCommit");
+        const claudeCodeManaged = config.get<boolean>("claudeCodeManaged", false);
+        const preferredMethod = config.get<string>("preferredMethod", "auto");
+
+        if (!(claudeCodeManaged && preferredMethod === "cli")) {
+          if (
+            repo.state.indexChanges.length === 0 &&
+            repo.state.workingTreeChanges.length === 0
+          ) {
+            vscode.window.showWarningMessage(
+              "No changes to commit. Stage files first."
+            );
+            return;
+          }
         }
 
         let commitMessage: string | null = null;

--- a/src/prompts/en.ts
+++ b/src/prompts/en.ts
@@ -63,6 +63,18 @@ docs(readme): updated installation instructions
 Return ONLY the commit message (one line), no explanations.`;
 }
 
+export function getManagedPrompt(keepCoAuthoredBy: boolean): string {
+  let prompt = `Generate a git commit message for current changes, in English, output only the commit message, no other text.`;
+  if (keepCoAuthoredBy) {
+    prompt += `
+
+Keep at the end of commit message:
+🤖 Generated with Claude Code
+Co-Authored-By: Claude <noreply@anthropic.com>`;
+  }
+  return prompt;
+}
+
 export function getEditPrompt(
   currentMessage: string,
   userFeedback: string,

--- a/src/prompts/generation.ts
+++ b/src/prompts/generation.ts
@@ -15,6 +15,11 @@ export function createGenerationPrompt(
   return module.getGenerationPrompt(diff, stats, multiLine);
 }
 
+export function createManagedPrompt(lang: Language, keepCoAuthoredBy: boolean): string {
+  const module = promptModules[lang];
+  return module.getManagedPrompt(keepCoAuthoredBy);
+}
+
 export function createEditPrompt(
   currentMessage: string,
   userFeedback: string,

--- a/src/prompts/ua.ts
+++ b/src/prompts/ua.ts
@@ -63,6 +63,18 @@ docs(readme): оновлено інструкції встановлення
 Поверни ТІЛЬКИ commit message (один рядок), без пояснень.`;
 }
 
+export function getManagedPrompt(keepCoAuthoredBy: boolean): string {
+  let prompt = `Згенеруй git commit message для поточних змін, українською мовою, лише commit message, без іншого тексту.`;
+  if (keepCoAuthoredBy) {
+    prompt += `
+
+В кінці commit message додай:
+🤖 Generated with Claude Code
+Co-Authored-By: Claude <noreply@anthropic.com>`;
+  }
+  return prompt;
+}
+
 export function getEditPrompt(
   currentMessage: string,
   userFeedback: string,

--- a/src/prompts/zh.ts
+++ b/src/prompts/zh.ts
@@ -63,6 +63,18 @@ docs(readme): 更新了安装说明
 仅返回 commit message（一行），不要有任何解释。`;
 }
 
+export function getManagedPrompt(keepCoAuthoredBy: boolean): string {
+  let prompt = `为当前改动生成git commit message，使用中文，仅输出commit message内容，不要有其他多余输出。`;
+  if (keepCoAuthoredBy) {
+    prompt += `
+
+commit message 末尾保留:
+🤖 Generated with Claude Code
+Co-Authored-By: Claude <noreply@anthropic.com>`;
+  }
+  return prompt;
+}
+
 export function getEditPrompt(
   currentMessage: string,
   userFeedback: string,

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -24,6 +24,8 @@ export interface ClaudeCommitConfig {
   language: "en" | "ua" | "zh";
   multiLineCommit: boolean;
   diffSource: "staged" | "all" | "auto";
+  claudeCodeManaged: boolean;
+  keepCoAuthoredBy: boolean;
 }
 
 export type ProgressCallback = (message: string) => void;


### PR DESCRIPTION
This commit introduces a **"claudeCodeManaged"** mode, which empowers Claude Code (specifically its Haiku model) to generate commit messages with minimal, language-only prompting. In this mode, the extension provides only a language hint, allowing the model to independently analyze the changes and generate the commit message.

This feature is designed for streamlined, high-quality commit generation by leveraging Claude Code's change analysis capabilities.

Key Changes:
* **Core Feature:** Implement `generateWithCLIManaged()` and `createManagedPrompt()` to enable minimal-prompt, CLI-based generation using Claude Code.
* **Validation:** Update git change detection to **skip validation** in managed mode, delegating this task entirely to Claude Code.
* **Configuration:** Introduce new configuration options:
    * `claudeCodeManaged`: Toggles the new minimal-prompt generation mode.
    * `keepCoAuthoredBy`: Ensures retention of the `Co-Authored-By` signature, supporting this feature across all languages.
* **Co-Authored-By Support:** Extend support for retaining the `Co-Authored-By` signature to all supported languages.

🤖 Generated with Claude Code

Co-Authored-By: Claude <noreply@anthropic.com>