### PR TITLE
perf(cli): speed up generation via direct spawn and settings isolation

### DIFF
--- a/src/cli/execution.ts
+++ b/src/cli/execution.ts
@@ -1,14 +1,148 @@
 import * as vscode from "vscode";
-import { exec } from "child_process";
-import { promisify } from "util";
-import * as fs from "fs";
+import { spawn } from "child_process";
 import * as path from "path";
-import * as os from "os";
 import { findClaudeCliPath } from "./detection";
 import type { ProgressCallback, Model } from "../types";
 import { log, logError, logCommand } from "../utils/logger";
 
-const execAsync = promisify(exec);
+const CLI_TIMEOUT_MS = 120000;
+const MAX_OUTPUT_BYTES = 10 * 1024 * 1024;
+
+const CLI_SPEEDUP_ENV: Record<string, string> = {
+  DISABLE_AUTOUPDATER: "1",
+  CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
+};
+
+const BASE_CLI_ARGS = [
+  "-p",
+  "--no-session-persistence",
+  "--tools",
+  "",
+  "--effort",
+  "low",
+  // Without this the CLI boots every MCP server from the user's global config.
+  "--strict-mcp-config",
+  // User CLAUDE.md/rules and hooks slow every call and steer output away from
+  // the commit message; auth still applies with no setting sources.
+  "--setting-sources",
+  "",
+];
+
+interface CliResult {
+  stdout: string;
+  stderr: string;
+}
+
+type CliError = Error & { killed?: boolean; code?: string; stderr?: string; stdout?: string };
+
+function runClaudeCli(cliPath: string, args: string[], stdin: string): Promise<CliResult> {
+  const env = {
+    ...process.env,
+    ...CLI_SPEEDUP_ENV,
+    // nvm/npm-global installs are `#!/usr/bin/env node` shims; node sits next to them.
+    PATH: `${path.dirname(cliPath)}${path.delimiter}${process.env.PATH ?? ""}`,
+  };
+
+  // .cmd/.bat wrappers on Windows only run through a shell.
+  const useShell = process.platform === "win32";
+  const command = useShell && cliPath.includes(" ") ? `"${cliPath}"` : cliPath;
+
+  return new Promise((resolve, reject) => {
+    const child = spawn(command, args, { env, shell: useShell, windowsHide: true });
+
+    let stdout = "";
+    let stderr = "";
+    let settled = false;
+    let timedOut = false;
+
+    const timer = setTimeout(() => {
+      timedOut = true;
+      child.kill("SIGKILL");
+    }, CLI_TIMEOUT_MS);
+
+    const fail = (error: CliError): void => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+      error.stderr = error.stderr ?? stderr;
+      error.stdout = error.stdout ?? stdout;
+      reject(error);
+    };
+
+    child.stdout.on("data", (chunk: Buffer) => {
+      stdout += chunk.toString("utf-8");
+      if (stdout.length > MAX_OUTPUT_BYTES) {
+        child.kill("SIGKILL");
+        fail(new Error("CLI output exceeded buffer limit"));
+      }
+    });
+
+    child.stderr.on("data", (chunk: Buffer) => {
+      stderr += chunk.toString("utf-8");
+    });
+
+    child.on("error", (error: CliError) => {
+      fail(error);
+    });
+
+    child.on("close", (code) => {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timer);
+
+      if (timedOut) {
+        const error: CliError = new Error("CLI process timed out");
+        error.killed = true;
+        error.stderr = stderr;
+        error.stdout = stdout;
+        reject(error);
+        return;
+      }
+
+      if (code !== 0) {
+        const error: CliError = new Error(`CLI exited with code ${code}`);
+        error.stderr = stderr;
+        error.stdout = stdout;
+        reject(error);
+        return;
+      }
+
+      resolve({ stdout, stderr });
+    });
+
+    // Ignore EPIPE when the process dies before reading stdin; close/error report the real failure.
+    child.stdin.on("error", () => {});
+    child.stdin.end(stdin);
+  });
+}
+
+function toCliError(error: unknown, cliPath: string): Error {
+  const err = error as CliError;
+  if (err.killed) {
+    return new Error("CLI process timed out after 2 minutes. Try a smaller diff or check your connection.");
+  }
+  if (err.code === "ENOENT") {
+    return new Error(`CLI executable not found at: ${cliPath}`);
+  }
+  const stderr = err.stderr?.trim() || "";
+  const stdout = err.stdout?.trim() || "";
+  const details: string[] = [];
+  if (stderr) {
+    details.push(`stderr: ${stderr}`);
+  }
+  if (stdout) {
+    details.push(`stdout: ${stdout}`);
+  }
+  const baseMessage = err.message || String(error);
+  const detailStr = details.length > 0 ? ` [${details.join("; ")}]` : "";
+  const fullError = `CLI execution failed: ${baseMessage}${detailStr}`;
+  logError(fullError, error);
+  return new Error(fullError);
+}
 
 /**
  * Strip markdown code fences (```...```) from Claude's output.
@@ -41,146 +175,106 @@ export async function generateWithCLI(
   }
 
   log(`Found Claude CLI at: ${cliPath}`);
-  const escapedCliPath = cliPath.includes(" ") ? `"${cliPath}"` : cliPath;
 
   const config = vscode.workspace.getConfiguration("claudeCommit");
   const model = config.get<Model>("model", "haiku");
-  const privacyMode = config.get<boolean>("privacyMode", false);
 
-  const tmpDir = os.tmpdir();
-  const promptFile = path.join(tmpDir, `claude-commit-prompt-${Date.now()}.txt`);
+  if (progressCallback) {
+    progressCallback(`Using ${model} model...`);
+  }
 
+  const args = [...BASE_CLI_ARGS, "--model", model];
+  logCommand(`${cliPath} ${args.join(" ")}`);
+
+  let stdout: string;
+  let stderr: string;
   try {
-    await fs.promises.writeFile(promptFile, prompt, { encoding: "utf-8", mode: privacyMode ? 0o600 : 0o644 });
-
-    if (progressCallback) {
-      progressCallback(`Using ${model} model...`);
-    }
-
-    const cliFlags = `-p --no-session-persistence --model ${model} --tools "" --effort low`;
-    const baseCommand =
-      process.platform === "win32"
-        ? `type "${promptFile}" | ${escapedCliPath} ${cliFlags}`
-        : `cat "${promptFile}" | ${escapedCliPath} ${cliFlags}`;
-
-    // Use login shell to load user's environment variables (e.g., from .bashrc, .profile)
-    const command = process.platform === "win32" ? baseCommand : `/bin/bash -l -c ${JSON.stringify(baseCommand)}`;
-
-    logCommand(command);
-
-    const { stdout, stderr } = await execAsync(command, {
-      maxBuffer: 10 * 1024 * 1024,
-      timeout: 120000,
-    });
-
-    if (stderr) {
-      log(`CLI stderr: ${stderr.trim()}`);
-    }
-    if (stdout) {
-      log(`CLI stdout (first 500 chars): ${stdout.substring(0, 500)}`);
-    } else {
-      log("CLI stdout is empty");
-    }
-
-    if (stderr && !stdout) {
-      throw new Error(`CLI error output: ${stderr.trim()}`);
-    }
-
-    if (!stdout || stdout.trim().length === 0) {
-      logError("Empty response from CLI", new Error(`Command: ${command}, stderr: ${stderr || "none"}`));
-      throw new Error("Empty response from CLI. Check Output panel for details.");
-    }
-
-    const cleanedStdout = stripCodeFences(stdout);
-
-    const lines = cleanedStdout
-      .split("\n")
-      .map((line) => line.trim())
-      .filter((line) => line.length > 0);
-
-    if (lines.length === 0) {
-      logError("No valid lines in CLI output", new Error(`stdout: ${stdout}`));
-      throw new Error("Empty response from CLI. Check Output panel for details.");
-    }
-
-    const multiLine = config.get<boolean>("multiLineCommit", false);
-    if (multiLine) {
-      const conventionalCommitPattern = /^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+?\))?:.+/;
-      let startIndex = -1;
-
-      for (let i = 0; i < lines.length; i++) {
-        if (conventionalCommitPattern.test(lines[i])) {
-          startIndex = i;
-          break;
-        }
-      }
-
-      // Use the non-trimmed cleaned stdout to preserve blank lines between subject/body/footer.
-      const preserveBlankLines = cleanedStdout.split("\n").map((line) => line.replace(/\s+$/u, ""));
-
-      // Drop leading empty lines
-      while (preserveBlankLines.length > 0 && preserveBlankLines[0].trim().length === 0) {
-        preserveBlankLines.shift();
-      }
-      // Drop trailing empty lines
-      while (preserveBlankLines.length > 0 && preserveBlankLines[preserveBlankLines.length - 1].trim().length === 0) {
-        preserveBlankLines.pop();
-      }
-
-      if (startIndex >= 0) {
-        // Find the same starting line in preserveBlankLines
-        const target = lines[startIndex];
-        const startInPreserve = preserveBlankLines.findIndex((l) => l.trim() === target);
-        if (startInPreserve >= 0) {
-          return preserveBlankLines.slice(startInPreserve).join("\n");
-        }
-        return lines.slice(startIndex).join("\n");
-      }
-
-      if (preserveBlankLines.length > 0) {
-        return preserveBlankLines.join("\n");
-      }
-    }
-
-    const conventionalCommitPattern = /^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+?\))?:.+/;
-
-    for (let i = lines.length - 1; i >= 0; i--) {
-      if (conventionalCommitPattern.test(lines[i])) {
-        return lines[i];
-      }
-    }
-
-    return lines[lines.length - 1] || "chore: update code";
+    ({ stdout, stderr } = await runClaudeCli(cliPath, args, prompt));
   } catch (error) {
-    const err = error as NodeJS.ErrnoException & { killed?: boolean; stderr?: string; stdout?: string };
-    if (err.killed) {
-      throw new Error("CLI process timed out after 2 minutes. Try a smaller diff or check your connection.");
+    throw toCliError(error, cliPath);
+  }
+
+  if (stderr) {
+    log(`CLI stderr: ${stderr.trim()}`);
+  }
+  if (stdout) {
+    log(`CLI stdout (first 500 chars): ${stdout.substring(0, 500)}`);
+  } else {
+    log("CLI stdout is empty");
+  }
+
+  if (stderr && !stdout) {
+    throw new Error(`CLI error output: ${stderr.trim()}`);
+  }
+
+  if (!stdout || stdout.trim().length === 0) {
+    logError(
+      "Empty response from CLI",
+      new Error(`Command: ${cliPath} ${args.join(" ")}, stderr: ${stderr || "none"}`)
+    );
+    throw new Error("Empty response from CLI. Check Output panel for details.");
+  }
+
+  const cleanedStdout = stripCodeFences(stdout);
+
+  const lines = cleanedStdout
+    .split("\n")
+    .map((line) => line.trim())
+    .filter((line) => line.length > 0);
+
+  if (lines.length === 0) {
+    logError("No valid lines in CLI output", new Error(`stdout: ${stdout}`));
+    throw new Error("Empty response from CLI. Check Output panel for details.");
+  }
+
+  const multiLine = config.get<boolean>("multiLineCommit", false);
+  if (multiLine) {
+    const conventionalCommitPattern = /^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+?\))?:.+/;
+    let startIndex = -1;
+
+    for (let i = 0; i < lines.length; i++) {
+      if (conventionalCommitPattern.test(lines[i])) {
+        startIndex = i;
+        break;
+      }
     }
-    if (err.code === "ENOENT") {
-      throw new Error(`CLI executable not found at: ${cliPath}`);
+
+    // Use the non-trimmed cleaned stdout to preserve blank lines between subject/body/footer.
+    const preserveBlankLines = cleanedStdout.split("\n").map((line) => line.replace(/\s+$/u, ""));
+
+    // Drop leading empty lines
+    while (preserveBlankLines.length > 0 && preserveBlankLines[0].trim().length === 0) {
+      preserveBlankLines.shift();
     }
-    // Provide detailed error information for debugging
-    const stderr = err.stderr?.trim() || "";
-    const stdout = err.stdout?.trim() || "";
-    const details: string[] = [];
-    if (stderr) {
-      details.push(`stderr: ${stderr}`);
+    // Drop trailing empty lines
+    while (preserveBlankLines.length > 0 && preserveBlankLines[preserveBlankLines.length - 1].trim().length === 0) {
+      preserveBlankLines.pop();
     }
-    if (stdout) {
-      details.push(`stdout: ${stdout}`);
+
+    if (startIndex >= 0) {
+      // Find the same starting line in preserveBlankLines
+      const target = lines[startIndex];
+      const startInPreserve = preserveBlankLines.findIndex((l) => l.trim() === target);
+      if (startInPreserve >= 0) {
+        return preserveBlankLines.slice(startInPreserve).join("\n");
+      }
+      return lines.slice(startIndex).join("\n");
     }
-    const baseMessage = err.message || String(error);
-    const detailStr = details.length > 0 ? ` [${details.join("; ")}]` : "";
-    const fullError = `CLI execution failed: ${baseMessage}${detailStr}`;
-    logError(fullError, error);
-    throw new Error(fullError);
-  } finally {
-    try {
-      await fs.promises.unlink(promptFile);
-    } catch {
-      // Ignore deletion errors
+
+    if (preserveBlankLines.length > 0) {
+      return preserveBlankLines.join("\n");
     }
   }
+
+  const conventionalCommitPattern = /^(feat|fix|docs|style|refactor|test|chore|perf)(\(.+?\))?:.+/;
+
+  for (let i = lines.length - 1; i >= 0; i--) {
+    if (conventionalCommitPattern.test(lines[i])) {
+      return lines[i];
+    }
+  }
+
+  return lines[lines.length - 1] || "chore: update code";
 }
 
 export async function generateWithCLIManaged(
@@ -194,86 +288,39 @@ export async function generateWithCLIManaged(
     throw new Error("Claude CLI path not found");
   }
 
-  const escapedCliPath = cliPath.includes(" ") ? `"${cliPath}"` : cliPath;
-
-  const config = vscode.workspace.getConfiguration("claudeCommit");
-  const privacyMode = config.get<boolean>("privacyMode", false);
-
-  const tmpDir = os.tmpdir();
-  const promptFile = path.join(tmpDir, `claude-commit-prompt-${Date.now()}.txt`);
-  const systemPromptFile = path.join(tmpDir, `claude-commit-system-${Date.now()}.txt`);
-
-  try {
-    await fs.promises.writeFile(promptFile, prompt, { encoding: "utf-8", mode: privacyMode ? 0o600 : 0o644 });
-    await fs.promises.writeFile(systemPromptFile, systemPrompt, {
-      encoding: "utf-8",
-      mode: privacyMode ? 0o600 : 0o644,
-    });
-
-    if (progressCallback) {
-      progressCallback("Using haiku model (managed mode)...");
-    }
-
-    const systemPromptEscaped = systemPromptFile.includes(" ") ? `"${systemPromptFile}"` : systemPromptFile;
-    const cliFlags = `-p --no-session-persistence --model haiku --tools "" --effort low --system-prompt "$(cat ${systemPromptEscaped})"`;
-    const baseCommand =
-      process.platform === "win32"
-        ? `type "${promptFile}" | ${escapedCliPath} -p --no-session-persistence --model haiku --tools "" --effort low`
-        : `cat "${promptFile}" | ${escapedCliPath} ${cliFlags}`;
-
-    // Use login shell to load user's environment variables (e.g., from .bashrc, .profile)
-    const command = process.platform === "win32" ? baseCommand : `/bin/bash -l -c ${JSON.stringify(baseCommand)}`;
-
-    logCommand(command);
-
-    const { stdout, stderr } = await execAsync(command, {
-      maxBuffer: 10 * 1024 * 1024,
-      timeout: 120000,
-    });
-
-    if (stderr) {
-      log(`CLI stderr: ${stderr.trim()}`);
-    }
-    if (stdout) {
-      log(`CLI stdout (first 500 chars): ${stdout.substring(0, 500)}`);
-    }
-
-    if (stderr && !stdout) {
-      throw new Error(`CLI error output: ${stderr.trim()}`);
-    }
-
-    return stripCodeFences(stdout) || "chore: update code";
-  } catch (error) {
-    const err = error as NodeJS.ErrnoException & { killed?: boolean; stderr?: string; stdout?: string };
-    if (err.killed) {
-      throw new Error("CLI process timed out after 2 minutes. Try a smaller diff or check your connection.");
-    }
-    if (err.code === "ENOENT") {
-      throw new Error(`CLI executable not found at: ${cliPath}`);
-    }
-    // Provide detailed error information for debugging
-    const stderr = err.stderr?.trim() || "";
-    const stdout = err.stdout?.trim() || "";
-    const details: string[] = [];
-    if (stderr) {
-      details.push(`stderr: ${stderr}`);
-    }
-    if (stdout) {
-      details.push(`stdout: ${stdout}`);
-    }
-    const baseMessage = err.message || String(error);
-    const detailStr = details.length > 0 ? ` [${details.join("; ")}]` : "";
-    const fullError = `CLI execution failed: ${baseMessage}${detailStr}`;
-    logError(fullError, error);
-    throw new Error(fullError);
-  } finally {
-    try {
-      await fs.promises.unlink(promptFile);
-      await fs.promises.unlink(systemPromptFile);
-    } catch {
-      // Ignore deletion errors
-    }
+  if (progressCallback) {
+    progressCallback("Using haiku model (managed mode)...");
   }
+
+  const args = [...BASE_CLI_ARGS, "--model", "haiku"];
+  // Windows runs through a shell (.cmd wrapper), where a multi-line system
+  // prompt cannot be quoted safely — skipped there, as before.
+  if (process.platform !== "win32") {
+    args.push("--system-prompt", systemPrompt);
+  }
+
+  logCommand(`${cliPath} ${args.filter((a) => a !== systemPrompt).join(" ")}`);
+
+  let stdout: string;
+  let stderr: string;
+  try {
+    ({ stdout, stderr } = await runClaudeCli(cliPath, args, prompt));
+  } catch (error) {
+    throw toCliError(error, cliPath);
+  }
+
+  if (stderr) {
+    log(`CLI stderr: ${stderr.trim()}`);
+  }
+  if (stdout) {
+    log(`CLI stdout (first 500 chars): ${stdout.substring(0, 500)}`);
+  }
+
+  if (stderr && !stdout) {
+    throw new Error(`CLI error output: ${stderr.trim()}`);
+  }
+
+  return stripCodeFences(stdout) || "chore: update code";
 }
 
 export async function generateWithAPI(

--- a/src/cli/execution.ts
+++ b/src/cli/execution.ts
@@ -15,14 +15,11 @@ const CLI_SPEEDUP_ENV: Record<string, string> = {
 
 const BASE_CLI_ARGS = ["-p", "--no-session-persistence", "--tools", "", "--effort", "low"];
 
-// Without these the CLI boots every MCP server from the user's global config
-// and injects user CLAUDE.md/rules and hooks, which slows every call and
-// steers output away from the commit message; auth still applies without
-// setting sources. Older CLI versions don't know these flags — see the
-// fallback in runClaudeCliIsolated.
+// Keeps the user's global CLAUDE.md/rules, hooks and MCP servers out of the
+// call — they slow generation and steer output away from the commit message.
 const ISOLATION_ARGS = ["--strict-mcp-config", "--setting-sources", ""];
 
-// null = not probed yet; probed once per extension-host session.
+// null = not probed yet.
 let isolationFlagsSupported: boolean | null = null;
 
 interface CliResult {

--- a/src/cli/execution.ts
+++ b/src/cli/execution.ts
@@ -13,20 +13,17 @@ const CLI_SPEEDUP_ENV: Record<string, string> = {
   CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC: "1",
 };
 
-const BASE_CLI_ARGS = [
-  "-p",
-  "--no-session-persistence",
-  "--tools",
-  "",
-  "--effort",
-  "low",
-  // Without this the CLI boots every MCP server from the user's global config.
-  "--strict-mcp-config",
-  // User CLAUDE.md/rules and hooks slow every call and steer output away from
-  // the commit message; auth still applies with no setting sources.
-  "--setting-sources",
-  "",
-];
+const BASE_CLI_ARGS = ["-p", "--no-session-persistence", "--tools", "", "--effort", "low"];
+
+// Without these the CLI boots every MCP server from the user's global config
+// and injects user CLAUDE.md/rules and hooks, which slows every call and
+// steers output away from the commit message; auth still applies without
+// setting sources. Older CLI versions don't know these flags — see the
+// fallback in runClaudeCliIsolated.
+const ISOLATION_ARGS = ["--strict-mcp-config", "--setting-sources", ""];
+
+// null = not probed yet; probed once per extension-host session.
+let isolationFlagsSupported: boolean | null = null;
 
 interface CliResult {
   stdout: string;
@@ -34,6 +31,30 @@ interface CliResult {
 }
 
 type CliError = Error & { killed?: boolean; code?: string; stderr?: string; stdout?: string };
+
+function isUnknownOptionError(error: unknown): boolean {
+  const err = error as CliError;
+  return `${err.message ?? ""}\n${err.stderr ?? ""}`.toLowerCase().includes("unknown option");
+}
+
+async function runClaudeCliIsolated(cliPath: string, args: string[], stdin: string): Promise<CliResult> {
+  if (isolationFlagsSupported === false) {
+    return runClaudeCli(cliPath, args, stdin);
+  }
+
+  try {
+    const result = await runClaudeCli(cliPath, [...ISOLATION_ARGS, ...args], stdin);
+    isolationFlagsSupported = true;
+    return result;
+  } catch (error) {
+    if (isolationFlagsSupported === null && isUnknownOptionError(error)) {
+      isolationFlagsSupported = false;
+      log("CLI does not support isolation flags (older version), retrying without them");
+      return runClaudeCli(cliPath, args, stdin);
+    }
+    throw error;
+  }
+}
 
 function runClaudeCli(cliPath: string, args: string[], stdin: string): Promise<CliResult> {
   const env = {
@@ -189,7 +210,7 @@ export async function generateWithCLI(
   let stdout: string;
   let stderr: string;
   try {
-    ({ stdout, stderr } = await runClaudeCli(cliPath, args, prompt));
+    ({ stdout, stderr } = await runClaudeCliIsolated(cliPath, args, prompt));
   } catch (error) {
     throw toCliError(error, cliPath);
   }
@@ -304,7 +325,7 @@ export async function generateWithCLIManaged(
   let stdout: string;
   let stderr: string;
   try {
-    ({ stdout, stderr } = await runClaudeCli(cliPath, args, prompt));
+    ({ stdout, stderr } = await runClaudeCliIsolated(cliPath, args, prompt));
   } catch (error) {
     throw toCliError(error, cliPath);
   }


### PR DESCRIPTION
## Problem

Commit message generation through the Claude CLI is slow — and for anyone with a customized Claude Code setup (global CLAUDE.md/rules, hooks, MCP servers) it is also unreliable, because the CLI loads the user's entire global configuration on every invocation:

- the user-level CLAUDE.md/rules set is injected into every call (~112 KB in my case), slowing generation and steering the model away from the task — it sometimes answered my global rules instead of returning a commit message;
- `Stop` hooks add a whole extra model turn;
- every configured MCP server is booted, even though commit generation needs no tools;
- the startup update check and telemetry add to every cold start.

Measured on macOS with haiku:

| Scenario | Before | After |
|---|---|---|
| Real commit generation (heavy global config) | ~26.8 s | 6–12 s |
| Trivial-prompt cold start | ~4.2 s | ~2.4 s |

## Changes

- Run the CLI directly via `spawn`, feeding the prompt through stdin — no login shell, no `cat`, no temp files. The diff never touches disk anymore, so the privacy guarantee that `privacyMode` approximated with file permissions now always holds for the CLI path.
- Pass `--setting-sources ""` and `--strict-mcp-config` so user/project settings, rules, hooks and MCP servers stay out of generation. Subscription auth is unaffected.
- Set `DISABLE_AUTOUPDATER=1` and `CLAUDE_CODE_DISABLE_NONESSENTIAL_TRAFFIC=1` for the spawned process.
- **Backward compatibility:** older CLI versions don't know the isolation flags. On an `unknown option` error the call is retried without them and the result is remembered for the session, so old CLIs keep working and pay the extra probe only on the first generation. Other errors propagate unchanged.

## Notes for review

- Managed mode is now also isolated from user settings. That is intentional (same speed/correctness reasoning), but it is a behavior change — happy to scope it differently if you prefer.
- The Windows path (`.cmd` wrapper via shell; system prompt still skipped there, as before) is logically equivalent to the previous code but I could not test it on a real Windows machine.
- Verified: lint + webpack build green; the fallback was exercised against stub CLIs (old CLI retries once then remembers, new CLI always uses the flags, real errors do not trigger a retry); end-to-end smoke test against the real CLI.
